### PR TITLE
Убрать fake_useragent и поставить статичный headers

### DIFF
--- a/dnevnikru.py
+++ b/dnevnikru.py
@@ -1,5 +1,4 @@
 import enum
-import fake_useragent
 import requests
 import urllib.parse
 from bs4 import BeautifulSoup
@@ -87,7 +86,8 @@ class Dnevnik:
         """
         self.login, self.password = login, password
         self.main_session = requests.Session()
-        self.main_session.headers.update({"User-Agent": fake_useragent.UserAgent().random})
+        self.main_session.headers.update({"User-Agent": "Mozilla/5.0 (Wayland; Linux x86_64) AppleWebKit/537.36 ("
+                                                        "KHTML, like Gecko) Chrome/94.0.4606.72 Safari/537.36"})
         self.main_session.post('https://login.dnevnik.ru/login', data={"login": self.login, "password": self.password})
         try:
             school = self.main_session.cookies['t0']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
-fake-useragent
 lxml
 bs4


### PR DESCRIPTION
В подобных проектах нет смысла подменивать user-agent при каждом запуске (не оправдано его использование)
Поэтому предлагаю сделать по умолчанию статичный юзер агент, так как обратившись к атрибуту **main_session** его всегда можно изменить (даже через тот самый fake_useragent), например:
```py
dn = Dnevnik("foo", "bar").main_session.headers.update({"User-Agent": "Mozilla 5.0 like gecko My user agent"})
dn.main_session.headers.update({"User-Agent": "Takoy user-agent hochu Linux Windows Macintosh"})
```