### PR TITLE
refactoring: replace() change to strip() in homework

### DIFF
--- a/dnevnikru.py
+++ b/dnevnikru.py
@@ -127,9 +127,8 @@ class Dnevnik:
                 homework_response = self.main_session.get(link + f"&page={page}", headers={"Referer": link}).text
                 for i in Utils.save_content(homework_response, class2='grid gridLines vam hmw'):
                     subject = [i[2],
-                               i[0].replace("\n\r\n" + " " * 24, "").replace("\r\n" + " " * 20 + "\n", ""),
-                               i[3].replace("\n" * 2, "").replace("\xa0", " ").replace("\r\n" + " " * 8 + "\t" * 3, "").
-                               replace("\r\n" + " " * 16 + "\r\n" + "\t" * 4 + " " * 4 + "\n", '')]
+                               i[0].strip(),
+                               i[3].strip()]
                     subjects.append(subject)
             return subjects
         if last_page is None:
@@ -137,9 +136,8 @@ class Dnevnik:
                 subjects = []
                 for i in Utils.save_content(homework_response, class2='grid gridLines vam hmw'):
                     subject = [i[2],
-                               i[0].replace("\n\r\n" + " " * 24, "").replace("\r\n" + " " * 20 + "\n", ""),
-                               i[3].replace("\n" * 2, "").replace("\xa0", " ").replace("\r\n" + " " * 8 + "\t" * 3, "").
-                               replace("\r\n" + " " * 16 + "\r\n" + "\t" * 4 + " " * 4 + "\n", '')]
+                               i[0].strip(),
+                               i[3].strip()]
                     subjects.append(subject)
                 return subjects
             except Exception:


### PR DESCRIPTION
Замена сложного и подогнанного под найденные строки метода .replace() на .strip(), так как [.strip() по умолчанию](https://docs.python.org/3/library/stdtypes.html#str.strip) без аргументов убирает все пробелы и отступы слева и справа от строки.