### PR TITLE
Добавление фильтра на колонки таблицы, получение данных из вложенных тэгов и атрибутов

### DIFF
--- a/dnevnikru/dnevnikru.py
+++ b/dnevnikru/dnevnikru.py
@@ -43,21 +43,33 @@ class Dnevnik:
             return None
 
     @staticmethod
-    def save_content(self, response, class2):
+    def save_content(self, response, class2, map2 = {}):
         """
         Функция для парсинга и сохранения таблиц с сайта
+        map2: необязательный фильтр на колонки вида {1:(), 2:('tag'), 3:('tag', 'attr')}
         """
         soup = BeautifulSoup(response, 'lxml')
         table = soup.find('table', {'class': class2})
         content = []
+        the_text = ''
         all_rows = table.findAll('tr')
         for row in all_rows:
             content.append([])
             all_cols = row.findAll('td')
-            for col in all_cols:
-                the_strings = [str(s) for s in col.findAll(text=True)]
-                the_text = ''.join(the_strings)
-                content[-1].append(the_text)
+            for (col_i, col) in enumerate(all_cols):
+                if len(map2) == 0:
+                    the_strings = [str(s) for s in col.findAll(text=True)]
+                    the_text = ''.join(the_strings)
+                    content[-1].append(the_text)
+                else:
+                    if col_i in map2:
+                        if len(map2[col_i]) == 0:
+                            the_strings = [str(s) for s in col.findAll(text=True)]
+                            the_text = ''.join(the_strings)
+                            content[-1].append(the_text)
+                        else:
+                            the_text = tuple((s.text, s.attrs[map2[col_i][1]] if len(map2[col_i]) > 1 else '') for s in col.findAll(map2[col_i][0]))
+                            content[-1].append(the_text)
         content = [a for a in content if a != []]
         return tuple(content)
 
@@ -143,9 +155,7 @@ class Dnevnik:
         link = settings.MARKS_LINK.format(self.school, index, period)
         marks_response = self.main_session.get(link, headers={"Referer": link}).text
         try:
-            marks = self.save_content(self, response=marks_response, class2='grid gridLines vam marks')
-            for mark in marks:
-                mark[2] = mark[2].replace(" ", "")
+            marks = self.save_content(self, marks_response, class2='grid gridLines vam marks', {0:(),1:(),2:('span', 'title'),6:()})
             return tuple(marks)
         except Exception as e:
             raise DnevnikError(e, "DnevnikError")


### PR DESCRIPTION
Изначальной целью доработки было разделение строки оценок и получение подробностей, а именно тип работы, за которую получена оценка. Заодно и фильтрация данных о посещаемости.
Для этого в функцию save_content добавил необязательный параметр map2. Если он пустой, то функция работает, как раньше. map2 это словарь, ключом в котором являются номера колонок, которые нужно вернуть. Значение словаря - это кортеж. Если пустой, то возвращается текст ячейки целиком. Если он заполнен (например ('tag', 'attr')), то внутри ячейки ищутся все тэги tag, извлекаются данные из атрибута 'attr', эти пары упаковываются в кортеж и возвращаются как значение ячейки. В итоге значение строки выглядит как 
'6',  'Математика',
  (('5', 'Ответ на уроке, 15 ноября 2021, 3 урок '),
   ('4', 'Ответ на уроке, 16 ноября 2021, 2 урок '),
   ('5', 'Математический диктант, 17 ноября 2021, 1 урок '),
   ('5', 'Ответ на уроке, 18 ноября 2021, 2 урок ')),
  '4,86'

Новый параметр применил в функции marks. Единственное, что в строке
> marks = self.save_content(self, marks_response, class2='grid gridLines vam marks', {0:(),1:(),2:('span', 'title'),6:()})

нужно либо убрать именование class2 или добавить именование map2. Сам поздно заметил.